### PR TITLE
Replace deprecated web views with WKWebView

### DIFF
--- a/BethesdaViewController.h
+++ b/BethesdaViewController.h
@@ -10,9 +10,4 @@
 
 @interface BethesdaViewController : UIViewController
 
-{ IBOutlet UIWebView *webview;
-}
-
-@property (nonatomic, retain) UIWebView *webview;
-
 @end

--- a/BethesdaViewController.m
+++ b/BethesdaViewController.m
@@ -7,14 +7,15 @@
 //
 
 #import "BethesdaViewController.h"
+@import WebKit;
 
 @interface BethesdaViewController ()
+
+@property (nonatomic, strong) WKWebView *webView;
 
 @end
 
 @implementation BethesdaViewController
-@synthesize webview;
-
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -27,18 +28,52 @@
 
 - (void)viewDidLoad
 {
-   // self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:255/255 green:102/255 blue:102/255 alpha:1];
     [super viewDidLoad];
-    NSString *path = [[ NSBundle mainBundle] pathForResource:@"table" ofType:@"html" ];
-    NSURL *url = [NSURL fileURLWithPath:path];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webview loadRequest:request];
+    [self configureWebViewIfNeeded];
+    [self loadHTMLResourceNamed:@"table"];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Private helpers
+
+- (void)configureWebViewIfNeeded
+{
+    if (self.webView != nil) {
+        return;
+    }
+
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:webView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.webView = webView;
+}
+
+- (void)loadHTMLResourceNamed:(NSString *)resourceName
+{
+    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"html"];
+    if (fileURL == nil) {
+        return;
+    }
+
+    if (@available(iOS 9.0, *)) {
+        [self.webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
+    } else {
+        NSURLRequest *request = [NSURLRequest requestWithURL:fileURL];
+        [self.webView loadRequest:request];
+    }
 }
 
 @end

--- a/CalcitonDoublingViewController.swift
+++ b/CalcitonDoublingViewController.swift
@@ -206,8 +206,8 @@ class CalcitonDoublingViewController: UIViewController, UITableViewDelegate, UIT
     
     
     
-   func dismissKeyboard(){
-    
+    @objc private func dismissKeyboard(){
+
         MarkerTxt.resignFirstResponder()
     }
     

--- a/TFTPregnancyViewController.h
+++ b/TFTPregnancyViewController.h
@@ -10,11 +10,4 @@
 
 @interface TFTPregnancyViewController : UIViewController
 
-
-{ IBOutlet UIWebView *webview;
-}
-
-@property (nonatomic, retain)  UIWebView *webview;
-
-
 @end

--- a/TFTPregnancyViewController.m
+++ b/TFTPregnancyViewController.m
@@ -7,13 +7,15 @@
 //
 
 #import "TFTPregnancyViewController.h"
+@import WebKit;
 
 @interface TFTPregnancyViewController ()
+
+@property (nonatomic, strong) WKWebView *webView;
 
 @end
 
 @implementation TFTPregnancyViewController
-@synthesize webview;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -27,20 +29,51 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-   // self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:255/255 green:102/255 blue:102/255 alpha:1];
-	
-    [super viewDidLoad];
-    NSString *path = [[ NSBundle mainBundle] pathForResource:@"pregnancy_tsh" ofType:@"html" ];
-    NSURL *url = [NSURL fileURLWithPath:path];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webview loadRequest:request];
-
+    [self configureWebViewIfNeeded];
+    [self loadHTMLResourceNamed:@"pregnancy_tsh"];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Private helpers
+
+- (void)configureWebViewIfNeeded
+{
+    if (self.webView != nil) {
+        return;
+    }
+
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:webView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.webView = webView;
+}
+
+- (void)loadHTMLResourceNamed:(NSString *)resourceName
+{
+    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"html"];
+    if (fileURL == nil) {
+        return;
+    }
+
+    if (@available(iOS 9.0, *)) {
+        [self.webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
+    } else {
+        NSURLRequest *request = [NSURLRequest requestWithURL:fileURL];
+        [self.webView loadRequest:request];
+    }
 }
 
 @end

--- a/TNMViewController.h
+++ b/TNMViewController.h
@@ -9,10 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface TNMViewController : UIViewController
-{ IBOutlet UIWebView *webview;
-}
-@property (nonatomic, retain)  UIWebView *webview;
-
-
 
 @end

--- a/TNMViewController.m
+++ b/TNMViewController.m
@@ -7,15 +7,15 @@
 //
 
 #import "TNMViewController.h"
+@import WebKit;
 
 @interface TNMViewController ()
+
+@property (nonatomic, strong) WKWebView *webView;
 
 @end
 
 @implementation TNMViewController
-
-@synthesize webview;
-
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -29,18 +29,51 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	//self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:255/255 green:102/255 blue:102/255 alpha:1];
-    [super viewDidLoad];
-    NSString *path = [[ NSBundle mainBundle] pathForResource:@"TNM" ofType:@"html" ];
-    NSURL *url = [NSURL fileURLWithPath:path];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webview loadRequest:request];
+    [self configureWebViewIfNeeded];
+    [self loadHTMLResourceNamed:@"TNM"];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Private helpers
+
+- (void)configureWebViewIfNeeded
+{
+    if (self.webView != nil) {
+        return;
+    }
+
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:webView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.webView = webView;
+}
+
+- (void)loadHTMLResourceNamed:(NSString *)resourceName
+{
+    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"html"];
+    if (fileURL == nil) {
+        return;
+    }
+
+    if (@available(iOS 9.0, *)) {
+        [self.webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
+    } else {
+        NSURLRequest *request = [NSURLRequest requestWithURL:fileURL];
+        [self.webView loadRequest:request];
+    }
 }
 
 @end

--- a/en.lproj/MainStoryboard.storyboard
+++ b/en.lproj/MainStoryboard.storyboard
@@ -16,28 +16,10 @@
                     <view key="view" contentMode="scaleToFill" id="CcA-g2-ZYP">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <webView clipsSubviews="YES" clearsContextBeforeDrawing="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" scalesPageToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IFG-AY-aLg">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <animations/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="0.0"/>
-                                <dataDetectorType key="dataDetectorTypes"/>
-                            </webView>
-                        </subviews>
                         <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="leading" secondItem="CcA-g2-ZYP" secondAttribute="leading" id="ELM-ac-xYs"/>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="top" secondItem="CcA-g2-ZYP" secondAttribute="top" id="a6e-I2-DUd"/>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="trailing" secondItem="CcA-g2-ZYP" secondAttribute="trailing" id="cMU-re-coF"/>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="bottom" secondItem="CcA-g2-ZYP" secondAttribute="bottom" id="g67-Xf-nv9"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="TNM staging thyroid ca" id="DJm-Gq-6TT"/>
-                    <connections>
-                        <outlet property="webview" destination="IFG-AY-aLg" id="RrC-fs-VR9"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tb7-MX-CoW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -821,26 +803,10 @@
                     <view key="view" contentMode="scaleToFill" id="dNH-SS-CcT">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a0o-0P-7zK">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <animations/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                            </webView>
-                        </subviews>
                         <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="bottom" secondItem="dNH-SS-CcT" secondAttribute="bottom" id="NNX-Is-bDI"/>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="top" secondItem="dNH-SS-CcT" secondAttribute="top" id="OQ4-7j-9dh"/>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="leading" secondItem="dNH-SS-CcT" secondAttribute="leading" id="e3f-FL-oOi"/>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="trailing" secondItem="dNH-SS-CcT" secondAttribute="trailing" id="vzR-9B-m3q"/>
-                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="TFT's in pregnancy" id="TIp-2z-7ri"/>
-                    <connections>
-                        <outlet property="webview" destination="a0o-0P-7zK" id="KkG-P6-bS2"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ebe-fs-waE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
## Summary
- replace the legacy UIWebView instances with programmatic WKWebView setups that load the bundled HTML content
- remove the obsolete UIWebView outlets from the storyboard scenes tied to the thyroid calculators
- ensure the Swift keyboard dismissal selector is exposed to Objective-C for modern Swift compilers

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8e17055e0832abb841eb436381c0b