### PR TITLE
Adopt system colors for modern appearance

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -12,23 +12,68 @@
 
 - (void)customizeAppearance
 {
-    
-    
-    // Set the background image for *all* UINavigationBars
-    
-    // Create resizable images
-    UIImage *gradientImage44 = [[UIImage imageNamed:@"surf_gradient_textured_44"]
-                                resizableImageWithCapInsets:UIEdgeInsetsMake(0, 0, 0, 0)];
-    UIImage *gradientImage32 = [[UIImage imageNamed:@"surf_gradient_textured_32"]
-                                resizableImageWithCapInsets:UIEdgeInsetsMake(0, 0, 0, 0)];
-    
-    // Set the background image for *all* UINavigationBars
-    [[UINavigationBar appearance] setBackgroundImage:gradientImage44
-                                       forBarMetrics:UIBarMetricsDefault];
-    [[UINavigationBar appearance] setBackgroundImage:gradientImage32
-                                       forBarMetrics:UIBarMetricsLandscapePhone];
-    
-    //[[UINavigationBar appearance] setBarTintColor:[UIColor colorWithRed:0 green:0.502 blue:0.502 alpha:1]];
+    UIColor *primaryColor;
+    UIColor *accentColor;
+    UIColor *backgroundColor;
+    UIColor *tableBackgroundColor;
+    UIColor *cellBackgroundColor;
+    UIColor *separatorColor;
+
+    if (@available(iOS 13.0, *)) {
+        primaryColor = [UIColor systemIndigoColor];
+        accentColor = [UIColor systemTealColor];
+        backgroundColor = [UIColor systemBackgroundColor];
+        tableBackgroundColor = [UIColor systemGroupedBackgroundColor];
+        cellBackgroundColor = [UIColor secondarySystemGroupedBackgroundColor];
+        separatorColor = [UIColor separatorColor];
+    } else {
+        primaryColor = [UIColor colorWithRed:0.16f green:0.2f blue:0.39f alpha:1.0f];
+        accentColor = [UIColor colorWithRed:0.02f green:0.47f blue:0.60f alpha:1.0f];
+        backgroundColor = [UIColor whiteColor];
+        tableBackgroundColor = [UIColor colorWithWhite:0.96f alpha:1.0f];
+        cellBackgroundColor = [UIColor whiteColor];
+        separatorColor = [UIColor colorWithWhite:0.8f alpha:1.0f];
+    }
+
+    UINavigationBar *navigationBarAppearance = [UINavigationBar appearance];
+    if (@available(iOS 13.0, *)) {
+        UINavigationBarAppearance *appearance = [[UINavigationBarAppearance alloc] init];
+        [appearance configureWithOpaqueBackground];
+        appearance.backgroundColor = primaryColor;
+        appearance.titleTextAttributes = @{ NSForegroundColorAttributeName : UIColor.whiteColor };
+        appearance.largeTitleTextAttributes = @{ NSForegroundColorAttributeName : UIColor.whiteColor };
+
+        navigationBarAppearance.tintColor = UIColor.whiteColor;
+        navigationBarAppearance.standardAppearance = appearance;
+        navigationBarAppearance.compactAppearance = appearance;
+        navigationBarAppearance.scrollEdgeAppearance = appearance;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+        if (@available(iOS 15.0, *)) {
+            navigationBarAppearance.compactScrollEdgeAppearance = appearance;
+        }
+#endif
+    } else {
+        [navigationBarAppearance setBarTintColor:primaryColor];
+        [navigationBarAppearance setTintColor:[UIColor whiteColor]];
+        [navigationBarAppearance setTitleTextAttributes:@{ NSForegroundColorAttributeName : [UIColor whiteColor] }];
+        navigationBarAppearance.translucent = NO;
+    }
+
+    [[UIView appearance] setTintColor:accentColor];
+    [[UITableView appearance] setBackgroundColor:tableBackgroundColor];
+    [[UITableView appearance] setSeparatorColor:separatorColor];
+    [[UITableViewCell appearance] setBackgroundColor:cellBackgroundColor];
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 150000
+    if (@available(iOS 15.0, *)) {
+        [[UITableView appearance] setSectionHeaderTopPadding:0.0f];
+    }
+#endif
+
+    if (self.window != nil) {
+        self.window.backgroundColor = backgroundColor;
+        self.window.tintColor = accentColor;
+    }
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions

--- a/BethesdaViewController.h
+++ b/BethesdaViewController.h
@@ -10,9 +10,4 @@
 
 @interface BethesdaViewController : UIViewController
 
-{ IBOutlet UIWebView *webview;
-}
-
-@property (nonatomic, retain) UIWebView *webview;
-
 @end

--- a/BethesdaViewController.m
+++ b/BethesdaViewController.m
@@ -7,14 +7,15 @@
 //
 
 #import "BethesdaViewController.h"
+@import WebKit;
 
 @interface BethesdaViewController ()
+
+@property (nonatomic, strong) WKWebView *webView;
 
 @end
 
 @implementation BethesdaViewController
-@synthesize webview;
-
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -27,18 +28,67 @@
 
 - (void)viewDidLoad
 {
-   // self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:255/255 green:102/255 blue:102/255 alpha:1];
     [super viewDidLoad];
-    NSString *path = [[ NSBundle mainBundle] pathForResource:@"table" ofType:@"html" ];
-    NSURL *url = [NSURL fileURLWithPath:path];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webview loadRequest:request];
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        self.view.backgroundColor = [UIColor whiteColor];
+    }
+    [self configureWebViewIfNeeded];
+    [self loadHTMLResourceNamed:@"table"];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Private helpers
+
+- (void)configureWebViewIfNeeded
+{
+    if (self.webView != nil) {
+        return;
+    }
+
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    UIColor *backgroundColor;
+    if (@available(iOS 13.0, *)) {
+        backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        backgroundColor = [UIColor whiteColor];
+    }
+    self.view.backgroundColor = backgroundColor;
+    webView.opaque = NO;
+    webView.backgroundColor = backgroundColor;
+    webView.scrollView.backgroundColor = backgroundColor;
+    [self.view addSubview:webView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.webView = webView;
+}
+
+- (void)loadHTMLResourceNamed:(NSString *)resourceName
+{
+    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"html"];
+    if (fileURL == nil) {
+        return;
+    }
+
+    if (@available(iOS 9.0, *)) {
+        [self.webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
+    } else {
+        NSURLRequest *request = [NSURLRequest requestWithURL:fileURL];
+        [self.webView loadRequest:request];
+    }
 }
 
 @end

--- a/CalcitonDoublingViewController.swift
+++ b/CalcitonDoublingViewController.swift
@@ -200,14 +200,26 @@ class CalcitonDoublingViewController: UIViewController, UITableViewDelegate, UIT
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemBackground
+            dateMarkerTable.backgroundColor = .secondarySystemBackground
+            dateMarkerTable.separatorColor = .separator
+        } else {
+            view.backgroundColor = .white
+            let tableBackground = UIColor(white: 0.96, alpha: 1.0)
+            dateMarkerTable.backgroundColor = tableBackground
+            dateMarkerTable.separatorColor = UIColor(white: 0.8, alpha: 1.0)
+        }
+        dateMarkerTable.tableFooterView = UIView(frame: .zero)
+
         MarkerTxt.delegate = self
         self.view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(CalcitonDoublingViewController.dismissKeyboard)))
     }
     
     
     
-   func dismissKeyboard(){
-    
+    @objc private func dismissKeyboard(){
+
         MarkerTxt.resignFirstResponder()
     }
     

--- a/TFTPregnancyViewController.h
+++ b/TFTPregnancyViewController.h
@@ -10,11 +10,4 @@
 
 @interface TFTPregnancyViewController : UIViewController
 
-
-{ IBOutlet UIWebView *webview;
-}
-
-@property (nonatomic, retain)  UIWebView *webview;
-
-
 @end

--- a/TFTPregnancyViewController.m
+++ b/TFTPregnancyViewController.m
@@ -7,13 +7,15 @@
 //
 
 #import "TFTPregnancyViewController.h"
+@import WebKit;
 
 @interface TFTPregnancyViewController ()
+
+@property (nonatomic, strong) WKWebView *webView;
 
 @end
 
 @implementation TFTPregnancyViewController
-@synthesize webview;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -27,20 +29,66 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-   // self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:255/255 green:102/255 blue:102/255 alpha:1];
-	
-    [super viewDidLoad];
-    NSString *path = [[ NSBundle mainBundle] pathForResource:@"pregnancy_tsh" ofType:@"html" ];
-    NSURL *url = [NSURL fileURLWithPath:path];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webview loadRequest:request];
-
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        self.view.backgroundColor = [UIColor whiteColor];
+    }
+    [self configureWebViewIfNeeded];
+    [self loadHTMLResourceNamed:@"pregnancy_tsh"];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Private helpers
+
+- (void)configureWebViewIfNeeded
+{
+    if (self.webView != nil) {
+        return;
+    }
+
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    UIColor *backgroundColor;
+    if (@available(iOS 13.0, *)) {
+        backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        backgroundColor = [UIColor whiteColor];
+    }
+    self.view.backgroundColor = backgroundColor;
+    webView.opaque = NO;
+    webView.backgroundColor = backgroundColor;
+    webView.scrollView.backgroundColor = backgroundColor;
+    [self.view addSubview:webView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.webView = webView;
+}
+
+- (void)loadHTMLResourceNamed:(NSString *)resourceName
+{
+    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"html"];
+    if (fileURL == nil) {
+        return;
+    }
+
+    if (@available(iOS 9.0, *)) {
+        [self.webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
+    } else {
+        NSURLRequest *request = [NSURLRequest requestWithURL:fileURL];
+        [self.webView loadRequest:request];
+    }
 }
 
 @end

--- a/TNMViewController.h
+++ b/TNMViewController.h
@@ -9,10 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface TNMViewController : UIViewController
-{ IBOutlet UIWebView *webview;
-}
-@property (nonatomic, retain)  UIWebView *webview;
-
-
 
 @end

--- a/TNMViewController.m
+++ b/TNMViewController.m
@@ -7,15 +7,15 @@
 //
 
 #import "TNMViewController.h"
+@import WebKit;
 
 @interface TNMViewController ()
+
+@property (nonatomic, strong) WKWebView *webView;
 
 @end
 
 @implementation TNMViewController
-
-@synthesize webview;
-
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
@@ -29,18 +29,66 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	//self.navigationController.navigationBar.barTintColor = [UIColor colorWithRed:255/255 green:102/255 blue:102/255 alpha:1];
-    [super viewDidLoad];
-    NSString *path = [[ NSBundle mainBundle] pathForResource:@"TNM" ofType:@"html" ];
-    NSURL *url = [NSURL fileURLWithPath:path];
-    NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    [webview loadRequest:request];
+    if (@available(iOS 13.0, *)) {
+        self.view.backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        self.view.backgroundColor = [UIColor whiteColor];
+    }
+    [self configureWebViewIfNeeded];
+    [self loadHTMLResourceNamed:@"TNM"];
 }
 
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
+}
+
+#pragma mark - Private helpers
+
+- (void)configureWebViewIfNeeded
+{
+    if (self.webView != nil) {
+        return;
+    }
+
+    WKWebView *webView = [[WKWebView alloc] initWithFrame:CGRectZero];
+    webView.translatesAutoresizingMaskIntoConstraints = NO;
+    UIColor *backgroundColor;
+    if (@available(iOS 13.0, *)) {
+        backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        backgroundColor = [UIColor whiteColor];
+    }
+    self.view.backgroundColor = backgroundColor;
+    webView.opaque = NO;
+    webView.backgroundColor = backgroundColor;
+    webView.scrollView.backgroundColor = backgroundColor;
+    [self.view addSubview:webView];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [webView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [webView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [webView.topAnchor constraintEqualToAnchor:self.view.topAnchor],
+        [webView.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor]
+    ]];
+
+    self.webView = webView;
+}
+
+- (void)loadHTMLResourceNamed:(NSString *)resourceName
+{
+    NSURL *fileURL = [[NSBundle mainBundle] URLForResource:resourceName withExtension:@"html"];
+    if (fileURL == nil) {
+        return;
+    }
+
+    if (@available(iOS 9.0, *)) {
+        [self.webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
+    } else {
+        NSURLRequest *request = [NSURLRequest requestWithURL:fileURL];
+        [self.webView loadRequest:request];
+    }
 }
 
 @end

--- a/en.lproj/MainStoryboard.storyboard
+++ b/en.lproj/MainStoryboard.storyboard
@@ -16,28 +16,10 @@
                     <view key="view" contentMode="scaleToFill" id="CcA-g2-ZYP">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <webView clipsSubviews="YES" clearsContextBeforeDrawing="NO" multipleTouchEnabled="YES" contentMode="scaleToFill" scalesPageToFit="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IFG-AY-aLg">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <animations/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="0.0"/>
-                                <dataDetectorType key="dataDetectorTypes"/>
-                            </webView>
-                        </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="leading" secondItem="CcA-g2-ZYP" secondAttribute="leading" id="ELM-ac-xYs"/>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="top" secondItem="CcA-g2-ZYP" secondAttribute="top" id="a6e-I2-DUd"/>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="trailing" secondItem="CcA-g2-ZYP" secondAttribute="trailing" id="cMU-re-coF"/>
-                            <constraint firstItem="IFG-AY-aLg" firstAttribute="bottom" secondItem="CcA-g2-ZYP" secondAttribute="bottom" id="g67-Xf-nv9"/>
-                        </constraints>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="TNM staging thyroid ca" id="DJm-Gq-6TT"/>
-                    <connections>
-                        <outlet property="webview" destination="IFG-AY-aLg" id="RrC-fs-VR9"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tb7-MX-CoW" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -51,8 +33,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
-                        <color key="backgroundColor" red="0.0" green="0.80000000000000004" blue="0.80000000000000004" alpha="1" colorSpace="calibratedRGB"/>
-                        <color key="tintColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+                        <color key="tintColor" systemColor="systemTealColor"/>
                         <sections>
                             <tableViewSection headerTitle="General" id="ZYZ-XN-6Ji">
                                 <cells>
@@ -68,7 +50,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -91,7 +73,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -114,7 +96,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -137,7 +119,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -164,7 +146,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -187,7 +169,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -210,7 +192,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -237,7 +219,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -260,7 +242,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -283,7 +265,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -310,7 +292,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -333,7 +315,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -356,7 +338,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -379,7 +361,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -402,7 +384,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -425,7 +407,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -448,7 +430,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <animations/>
                                                     <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <color key="textColor" systemColor="labelColor"/>
                                                     <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 </label>
                                             </subviews>
@@ -501,14 +483,14 @@
                                 <rect key="frame" x="28" y="96" width="148" height="23"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Thyroxine dose" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2al-5c-evV">
                                 <rect key="frame" x="28" y="161" width="129" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="nM5-Pq-3eX">
@@ -531,7 +513,7 @@
                             </textField>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="9pv-wn-BUr" firstAttribute="leading" secondItem="SCn-Fb-FBl" secondAttribute="leading" id="0jn-Oy-Wyw"/>
                             <constraint firstItem="JET-S6-Ydi" firstAttribute="top" secondItem="JyC-MO-sQx" secondAttribute="bottom" constant="32" id="HkS-3R-XSI"/>
@@ -577,7 +559,7 @@
                                 <rect key="frame" x="41" y="100" width="128" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fructosamine" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0BY-dO-GYk">
@@ -624,7 +606,7 @@
                             </textField>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="sQi-XI-Rxn" firstAttribute="top" secondItem="74r-w5-wX0" secondAttribute="bottom" constant="27" id="0nB-Uh-UbR"/>
                             <constraint firstItem="R7o-Ew-Sew" firstAttribute="top" secondItem="sQi-XI-Rxn" secondAttribute="bottom" constant="21" id="3O2-IG-Csa"/>
@@ -687,7 +669,7 @@
                                 <rect key="frame" x="20" y="105" width="40" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="From" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C0f-oE-dsL">
@@ -697,14 +679,14 @@
                                     <constraint firstAttribute="height" constant="83" id="ms6-NC-bzh"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="To" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MAS-87-Q2R">
                                 <rect key="frame" x="174" y="105" width="18" height="83"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="prednisone" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0vQ-RA-JGS">
@@ -753,7 +735,7 @@
                                 <rect key="frame" x="20" y="348" width="52" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="mg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dxg-Bk-DZl">
@@ -764,7 +746,7 @@
                             </label>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="DVI-KJ-9kr" secondAttribute="bottom" id="1en-tl-XxQ"/>
                             <constraint firstItem="eBE-2D-EB2" firstAttribute="leading" secondItem="0vQ-RA-JGS" secondAttribute="leading" id="2Nf-af-Zae"/>
@@ -821,26 +803,10 @@
                     <view key="view" contentMode="scaleToFill" id="dNH-SS-CcT">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <subviews>
-                            <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="a0o-0P-7zK">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <animations/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                            </webView>
-                        </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
-                        <constraints>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="bottom" secondItem="dNH-SS-CcT" secondAttribute="bottom" id="NNX-Is-bDI"/>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="top" secondItem="dNH-SS-CcT" secondAttribute="top" id="OQ4-7j-9dh"/>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="leading" secondItem="dNH-SS-CcT" secondAttribute="leading" id="e3f-FL-oOi"/>
-                            <constraint firstItem="a0o-0P-7zK" firstAttribute="trailing" secondItem="dNH-SS-CcT" secondAttribute="trailing" id="vzR-9B-m3q"/>
-                        </constraints>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="TFT's in pregnancy" id="TIp-2z-7ri"/>
-                    <connections>
-                        <outlet property="webview" destination="a0o-0P-7zK" id="KkG-P6-bS2"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ebe-fs-waE" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -1019,7 +985,7 @@
                             </textField>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="Nodule volume calculator" id="qBc-NJ-Gqf"/>
                     <connections>
@@ -1083,14 +1049,14 @@
                                 <rect key="frame" x="16" y="231" width="133" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Insulin sensitivity factor " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1v-VX-9Ug">
                                 <rect key="frame" x="16" y="301" width="184" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="niG-Tc-UaB">
@@ -1109,14 +1075,14 @@
                                 <rect key="frame" x="16" y="124" width="135" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="General information. Should be induvidualized for patients" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bwi-gF-8Y2">
                                 <rect key="frame" x="26" y="463" width="445" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -1150,98 +1116,98 @@
                                 <rect key="frame" x="30" y="100" width="62" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Levothyroxine" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JW5-Pp-aLT">
                                 <rect key="frame" x="200" y="100" width="108" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="1/4 grain (15 mg)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uwk-ds-i2Y">
                                 <rect key="frame" x="30" y="150" width="130" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="25 mcg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FMg-iy-qS7">
                                 <rect key="frame" x="200" y="150" width="58" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="1/2 grain (30 mg) " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GNM-Ja-NaV">
                                 <rect key="frame" x="30" y="200" width="135" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="50 mcg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mID-4U-0Pa">
                                 <rect key="frame" x="200" y="200" width="58" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="1 grain (60 mg)" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6S9-Hj-QWZ">
                                 <rect key="frame" x="30" y="250" width="115" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="100 mcg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ys1-aD-xvg">
                                 <rect key="frame" x="200" y="250" width="67" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="1.5 grain (90 mg) " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TYY-c6-e9y">
                                 <rect key="frame" x="30" y="300" width="134" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="150 mcg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQg-Nt-y13">
                                 <rect key="frame" x="200" y="300" width="67" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="2 grain (120 mg) " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FYj-Pk-mMc">
                                 <rect key="frame" x="30" y="350" width="129" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="200 mcg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="me8-fH-KfV">
                                 <rect key="frame" x="200" y="350" width="67" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" misplaced="YES" text="3 grain (180 mg) " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5k8-Td-CVH">
                                 <rect key="frame" x="30" y="400" width="129" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="300 mcg" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kLX-zQ-Do3">
                                 <rect key="frame" x="200" y="400" width="67" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
@@ -1339,7 +1305,7 @@
                             </button>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="88T-ZG-FvA" secondAttribute="trailing" constant="53" id="FSE-Of-ma8"/>
                             <constraint firstItem="Flx-UM-hHM" firstAttribute="leading" secondItem="QqD-Q3-VEM" secondAttribute="leading" id="JUw-3d-BZF"/>
@@ -1446,21 +1412,21 @@
                                 <rect key="frame" x="20" y="101" width="130" height="24"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="24 hr RAI uptake" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bt7-6N-4C1">
                                 <rect key="frame" x="20" y="178" width="142" height="24"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="RAI dose in mCi" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="no5-I6-MRS">
                                 <rect key="frame" x="20" y="245" width="130" height="22"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" borderStyle="roundedRect" placeholder="RAI dose" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="DFq-rm-L1B">
@@ -1484,7 +1450,7 @@
                             </button>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="s6D-TL-9PK" firstAttribute="top" secondItem="no5-I6-MRS" secondAttribute="bottom" constant="41" id="08t-hu-lc0"/>
                             <constraint firstItem="no5-I6-MRS" firstAttribute="top" secondItem="Bt7-6N-4C1" secondAttribute="bottom" constant="43" id="0PN-By-26Y"/>
@@ -1551,13 +1517,13 @@
                                 <string key="text">uCi given = [(estimated thyroid weight in grams) 
 	   X (uCi/g for appropriate weight from Table below) ]
 		/ (fractional RAIU at 24 hours)</string>
-                                <color key="textColor" red="0.50196081400000003" green="0.0" blue="0.50196081400000003" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="KoX-xP-0t7" firstAttribute="leading" secondItem="jHu-hn-45L" secondAttribute="leading" constant="40" id="Rb6-Ek-v0h"/>
                             <constraint firstItem="KoX-xP-0t7" firstAttribute="top" secondItem="ciH-SO-Qsx" secondAttribute="bottom" constant="22" id="g2e-E1-88d"/>
@@ -1605,14 +1571,14 @@
                                     <constraint firstAttribute="width" constant="65" id="O8f-2l-b9I"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Kilogram" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9jf-j4-6Ev">
                                 <rect key="frame" x="57" y="165" width="88" height="22"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="a75-vG-0xU">
@@ -1634,12 +1600,12 @@
                                 <rect key="frame" x="90" y="250" width="131" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="9jf-j4-6Ev" firstAttribute="leading" secondItem="SQL-EW-3qV" secondAttribute="leading" id="15z-ea-kSc"/>
                             <constraint firstItem="ohe-6f-vc2" firstAttribute="top" secondItem="V29-q4-6YE" secondAttribute="top" id="3xQ-D6-cek"/>
@@ -1727,7 +1693,7 @@
                                 <rect key="frame" x="99" y="146" width="87" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Inches" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bkk-ob-b9u">
@@ -1809,7 +1775,7 @@
                             </button>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Aql-2T-EmG" firstAttribute="trailing" secondItem="Fov-tm-h2W" secondAttribute="trailing" id="2Cn-dW-c7c"/>
                             <constraint firstItem="Atl-iQ-oHR" firstAttribute="leading" secondItem="Fov-tm-h2W" secondAttribute="leading" id="3eZ-Bx-z8h"/>
@@ -1891,7 +1857,7 @@
                                 <rect key="frame" x="20" y="100" width="31" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="GEG-7W-43W">
@@ -1970,7 +1936,7 @@
                             </textField>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="aMc-an-vxW" firstAttribute="leading" secondItem="6Um-bh-Fl3" secondAttribute="leading" id="1GH-DQ-TJr"/>
                             <constraint firstItem="aMc-an-vxW" firstAttribute="leading" secondItem="smm-7A-J7N" secondAttribute="leading" constant="20" symbolic="YES" id="1w9-dj-heg"/>
@@ -2125,7 +2091,7 @@
                             </label>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                     <navigationItem key="navigationItem" title="Fractional excretion of Ca" id="c4R-2b-FRM"/>
                     <connections>
@@ -2166,7 +2132,7 @@
                                 <rect key="frame" x="36" y="100" width="69" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Phosphorous" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OfA-ik-b9W">
@@ -2220,13 +2186,13 @@
                                 <rect key="frame" x="20" y="336" width="280" height="131"/>
                                 <animations/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                <color key="textColor" red="0.50196081399917603" green="0.0" blue="0.50196081399917603" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="OfA-ik-b9W" firstAttribute="bottom" secondItem="qhc-f1-Reo" secondAttribute="bottom" id="1Nc-TC-du4"/>
                             <constraint firstItem="qhc-f1-Reo" firstAttribute="top" secondItem="sMx-KK-3NC" secondAttribute="bottom" constant="21" id="1PZ-dt-PbI"/>
@@ -2293,7 +2259,7 @@
                                 <rect key="frame" x="36" y="100" width="62" height="21"/>
                                 <animations/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Glucose" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QEK-II-w7m">
@@ -2345,7 +2311,7 @@
                             </button>
                         </subviews>
                         <animations/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="BmO-0A-32D" firstAttribute="top" secondItem="8ts-T6-pvr" secondAttribute="bottom" constant="21" id="6u0-eK-gwn"/>
                             <constraint firstItem="BmO-0A-32D" firstAttribute="leading" secondItem="Efu-qo-MLN" secondAttribute="leading" id="9J8-GC-78f"/>


### PR DESCRIPTION
## Summary
- replace the legacy UIWebView instances with programmatic WKWebView setups that load the bundled HTML content
- remove the obsolete UIWebView outlets from the storyboard scenes tied to the thyroid calculators
- ensure the Swift keyboard dismissal selector is exposed to Objective-C for modern Swift compilers
- refresh the visual theme with system-provided colors, updated navigation bar appearance APIs, and dynamic backgrounds across storyboard scenes and calculators

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c8e17055e0832abb841eb436381c0b